### PR TITLE
languageフィールドに「日本語」を追加

### DIFF
--- a/unicode/jecon_unicode.bst
+++ b/unicode/jecon_unicode.bst
@@ -3869,7 +3869,11 @@ FUNCTION {set.is.kanji.entry.manual}
     { #0 'is.kanji.entry := }
     { language "ja" =
        { #1 'is.kanji.entry := }
-       { #0 'is.kanji.entry := }
+           { language "日本語" =
+               { #1 'is.kanji.entry := }
+               { #0 'is.kanji.entry := }
+         if$
+       }
       if$
     }
   if$


### PR DESCRIPTION
Zotero でamazon にある書籍をZoteroに保存すると, 言語の欄は「日本語」となることが多いのでその対応です. 