### PR TITLE
jnoteフィールドの追加

### DIFF
--- a/jecon-example.bib
+++ b/jecon-example.bib
@@ -404,10 +404,12 @@
   publisher    = {MIT Press},
   address      = {Cambridge, MA},
   year         = 1999,
+  note         = {紹介ページ: \url{https://mitpress.mit.edu/books/spatial-economy}},
   jauthor      = {小出, 博之},
   jtitle       = {空間経済学},
   jpublisher   = {東洋経済新報社},
-  jyear        = 2000
+  jyear        = 2000,
+  jnote        = {和訳紹介ページ: \url{https://str.toyokeizai.net/books/9784492312858/}}
 }
 
 @Book{Ryza15:_advan_analy_spark_patter_learn_data_scale,

--- a/jecon-example.bib
+++ b/jecon-example.bib
@@ -412,6 +412,20 @@
   jnote        = {和訳紹介ページ: \url{https://str.toyokeizai.net/books/9784492312858/}}
 }
 
+@book{romer19jp:_advan_macroecon,
+	author     = {Romer, David},
+	title      = {Advanced Macroeconomics},
+	publisher  = {McGraw Hill},
+	address    = {New York, NY},
+	year       = {2019},
+	edition    = {5th},
+	jauthor    = {堀, 雅博 and 岩成, 博夫 and 南條, 隆},
+	jtitle     = {上級マクロ経済学},
+	jyear      = {2010},
+	jpublusher = {日本評論社},
+	jnote      = {原著第3版訳}
+}
+
 @Book{Ryza15:_advan_analy_spark_patter_learn_data_scale,
   author       = {Sandy Ryza and Uri Laserson and Sean Owen and Josh Wills},
   title        = {Advanced Analytics with Spark Patterns for Learning from Data at Scale},

--- a/jecon-example.tex
+++ b/jecon-example.tex
@@ -385,9 +385,8 @@ Reference 部分の形式がどうなるかは，この文書の参考文献の�
 \subsubsection{邦訳書の情報も付ける場合} \label{sec:hoyakusho}
 
 また book に関しては，以下のように \texttt{jauthor}，\texttt{jkanyaku}，
-\texttt{jtitle}，\texttt{jpublisher}，\texttt{jyear} を指定することで邦訳書の情
-報を付け加えることができます（これは \texttt{jpolisci.bst} の機能をそのまま使わ
-せていただいています）．以下の指定が参考文献部分にどう反映されるかは，後の参考文
+\texttt{jtitle}，\texttt{jpublisher}，\texttt{jyear}, \texttt{jnote} を指定することで邦訳書の情
+報を付け加えることができます（これは \texttt{jpolisci.bst} の機能に \texttt{jnote} を新たに追加させていただいています）．以下の指定が参考文献部分にどう反映されるかは，後の参考文
 献部分を見て確認してください．\\
 
 \begin{screen}
@@ -398,10 +397,12 @@ Reference 部分の形式がどうなるかは，この文書の参考文献の�
   publisher =    {MIT Press},
   address =      {Cambridge, MA},
   year =         1999,
+  note =         {紹介ページ: \url{https://mitpress.mit.edu/books/spatial-economy}},
   jauthor =      {小出, 博之},
   jtitle =       {空間経済学},
   jpublisher =   {東洋経済新報社},
-  jyear =        2000
+  jyear =        2000,
+  jnote =        {和訳紹介ページ: \url{https://str.toyokeizai.net/books/9784492312858/}}
 }
  \end{verbatim}
 \end{screen}

--- a/jecon-example.tex
+++ b/jecon-example.tex
@@ -387,7 +387,7 @@ Reference 部分の形式がどうなるかは，この文書の参考文献の�
 また book に関しては，以下のように \texttt{jauthor}，\texttt{jkanyaku}，
 \texttt{jtitle}，\texttt{jpublisher}，\texttt{jyear}, \texttt{jnote} を指定することで邦訳書の情
 報を付け加えることができます（これは \texttt{jpolisci.bst} の機能に \texttt{jnote} を新たに追加させていただいています）．以下の指定が参考文献部分にどう反映されるかは，後の参考文
-献部分を見て確認してください．\\
+献部分の\cite{fujita99jp:_spatial_econom}, \cite{romer19jp:_advan_macroecon}を見て確認してください．\\
 
 \begin{screen}
  \begin{verbatim}
@@ -403,6 +403,24 @@ Reference 部分の形式がどうなるかは，この文書の参考文献の�
   jpublisher =   {東洋経済新報社},
   jyear =        2000,
   jnote =        {和訳紹介ページ: \url{https://str.toyokeizai.net/books/9784492312858/}}
+}
+ \end{verbatim}
+\end{screen}
+\vspace*{1em}
+\begin{screen}
+ \begin{verbatim}
+@book{romer19jp:_advan_macroecon,
+  author     = {Romer, David},
+  title      = {Advanced Macroeconomics},
+  publisher  = {McGraw Hill},
+  address    = {New York, NY},
+  year       = {2019},
+  edition    = {5th},
+  jauthor    = {堀, 雅博 and 岩成, 博夫 and 南條, 隆},
+  jtitle     = {上級マクロ経済学},
+  jyear      = {2010},
+  jpublusher = {日本評論社},
+  jnote      = {原著第3版訳}
 }
  \end{verbatim}
 \end{screen}

--- a/jecon.bst
+++ b/jecon.bst
@@ -3187,13 +3187,13 @@ FUNCTION {format.hoyakusho}
       jauthor empty$
 	{ jkanyaku empty$
 	    { "" * }
-	    { jkanyaku format.names * "監訳" * }
+	    { "xxx" jkanyaku format.names * "監訳" * }
 	  if$
 	}
-	{ jauthor format.names * "訳" *
+	{ "xxx" jauthor format.names * "訳" *
 	  jkanyaku empty$
 	    { "" * }
-	    { bst.touten.jp * jkanyaku format.names * "監訳" * }
+	    { bst.touten.jp * "xxx" jkanyaku format.names * "監訳" * }
 	  if$
 	}
       if$

--- a/jecon.bst
+++ b/jecon.bst
@@ -63,7 +63,7 @@ ENTRY
     school series title type url volume year yomi language
 
     % 以下は普通の bst ファイルでは利用されないフィールド
-    jauthor jkanyaku jtitle jpublisher jyear
+    jauthor jkanyaku jtitle jpublisher jyear jnote
     order absorder translator kanyaku nameorder
   }
 
@@ -3175,7 +3175,8 @@ FUNCTION {format.hoyakusho}
   jtitle empty$
   jpublisher empty$
   jyear empty$
-  and and and and
+  jnote empty$
+  and and and and and
     { "" }
     {
       is.kanji.entry
@@ -3186,13 +3187,13 @@ FUNCTION {format.hoyakusho}
       jauthor empty$
 	{ jkanyaku empty$
 	    { "" * }
-	    { "xxx" jkanyaku format.names * "監訳" * }
+	    { jkanyaku format.names * "監訳" * }
 	  if$
 	}
-	{ "xxx" jauthor format.names * "訳" *
+	{ jauthor format.names * "訳" *
 	  jkanyaku empty$
 	    { "" * }
-	    { bst.touten.jp * "xxx" jkanyaku format.names * "監訳" * }
+	    { bst.touten.jp * jkanyaku format.names * "監訳" * }
 	  if$
 	}
       if$
@@ -3206,11 +3207,14 @@ FUNCTION {format.hoyakusho}
       if$
       jyear empty$
 	{ "" * }
-	{ "" * jyear convert.year.kanji * "年" * }
+	{ "" * jyear convert.year.kanji * "年" * bst.touten.jp * }
+      if$ jnote empty$
+    { "" * }
+    { "" * jnote *}
       if$
       remove.irrelevant.kutoten bst.hoyakusho.post.jp *
     }
- if$
+     if$
 }
 
 FUNCTION {format.url}
@@ -3419,11 +3423,10 @@ FUNCTION {book}
     { format.year "year" output.check.nocomma }
     'skip$
   if$
-
-  format.hoyakusho output.nocomma
+  
   format.url.doi output.nocomma
-
   format.note output.nocomma
+  format.hoyakusho output.nocomma
   fin.entry
 }
 


### PR DESCRIPTION
#10 に対するPRです

`bst`だけでなく`jecon-example.bib`, `jecon-example.tex`に用例も追加しました. Fujita & Krugman "Spatial Economy" に原著と邦訳の版元ページを注釈に記載しました(が, 見た目が悪いかもしれません). 加えてローマーの『上級マクロ経済学』は邦訳と原著の版が違うので今回の修正の用例として良いかと思い追加しました. そちらと環境が違うかもしれませんので, `pdf` はPRに含めていません. (TeX Live 2020/pLaTeX で生成できることは確認しています)