### PR TITLE
jecon-example.texのuplatex対応・日本語LaTeXの新常識2021対応

### DIFF
--- a/jecon-example.tex
+++ b/jecon-example.tex
@@ -14,7 +14,8 @@
 % jsarticle ではエンジンを指定する → ここでは platex でコンパイル。
 % platex を使う場合は plautopatch パッケージを読み込んでおく。
 \RequirePackage{plautopatch}
-\documentclass[platex]{jsarticle}
+\documentclass[dvipdfmx, platex]{jsarticle} % for platex
+% \documentclass[dvipdfmx, uplatex]{jsarticle} % for uplatex
 
 %% natbib.sty を使う．
 \usepackage{natbib}


### PR DESCRIPTION
`jecon-example.tex` に対して以下の変更を加えます。
* uplatexでコンパイルできるようにする
* [日本語LaTeXの新常識2021](https://qiita.com/wtsnjp/items/76557b1598445a1fc9da)で推奨されている記述適用