### PR TITLE
TeXファイルの文面修正

### DIFF
--- a/jecon-example.tex
+++ b/jecon-example.tex
@@ -822,7 +822,7 @@ FUNCTION {bst.pbibtex.version}
 指定する必要があります。この指定はそのためのものです。
 
 第 \ref{jecon-example-sec:langid} 節で \texttt{langid} フィールドの指定は特殊な
-場合に必要になると書きましたら、このケースがそれです。TeX Live 2021 以降の新しい
+場合に必要になると書きましたが、このケースがそれです。TeX Live 2021 以降の新しい
 \texttt{upbibtex} では、日本語文献かどうかの自動判別が適切に機能するため、この
 \texttt{langid} フィールドの指定は必要ないです。
 


### PR DESCRIPTION
`jecon-example.tex` の文面が一部誤っていたので修正します。