### PR TITLE
Convert month from string to number for sorting

### DIFF
--- a/jecon.bst
+++ b/jecon.bst
@@ -4679,7 +4679,7 @@ FUNCTION {presort.one}
 	  { month add.zero.to.number "000" =
 	     % 000 のときは /// (これは数字よりは前)
 	     { * month add.zero.to.number * "/// " * }
-	     { * month add.zero.to.number * " " * }
+	     { * month convert.month convert.month.kanji add.zero.to.number * " " * }
 	    if$
 	  }
 	 if$
@@ -4785,7 +4785,7 @@ FUNCTION {presort.two}
 	  { month add.zero.to.number "000" =
 	     % 000 のときは /// (これは数字よりは前)
 	     { * month add.zero.to.number * "/// " * }
-	     { * month add.zero.to.number * " " * }
+	     { * month convert.month convert.month.kanji add.zero.to.number * " " * }
 	    if$
 	  }
 	 if$


### PR DESCRIPTION
ソートキー作成時に月が文字列のまま使われているためソートが正しくないようなので数値に変換するパッチです．
修正方法が間違っていたら直していただけると幸いです．